### PR TITLE
add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+beautifulsoup4==4.13.4
+certifi==2025.4.26
+charset-normalizer==3.4.2
+idna==3.10
+pillow==11.2.1
+requests==2.32.3
+soupsieve==2.7
+tk==0.1.0
+typing_extensions==4.13.2
+urllib3==2.4.0


### PR DESCRIPTION
lets people use venv and do `pip install -r` instead of manually checking what needs to be installed